### PR TITLE
DM-24521: Fix test failure with ts_salobj v5.10.0

### DIFF
--- a/tests/test_mock_devices.py
+++ b/tests/test_mock_devices.py
@@ -457,7 +457,7 @@ class MockDevicesTestCase(asynctest.TestCase):
             await self.run_command(track_command)
             self.assertAlmostEqual(device.actuator.target.position, position)
             self.assertAlmostEqual(device.actuator.target.velocity, velocity)
-            self.assertAlmostEqual(device.actuator.target.tai, tai)
+            self.assertAlmostEqual(device.actuator.target.tai, tai, delta=1e-5)
             await asyncio.sleep(0.1)
 
         # Disable tracking and check state


### PR DESCRIPTION
The translation from TAI unix to Astropy.time.Time and back
is not quite as precise as it used to be.