### PR TITLE
Fix the way the CSC starts the mock controller

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,22 @@
 Version History
 ###############
 
+v0.7.2
+======
+
+Changes:
+
+* Fix a bug that prevents the CSC from starting the mock TMA controller.
+* Added missing ``enable`` constructor argument to `MTMountCommander`.
+
+Requires:
+
+* ts_salobj 6
+* ts_simactuators 2
+* ts_hexrotcomm 0.9
+* ts_idl 2
+* IDL files for NewMTMount and MTMount from ts_xml 4.8
+
 v0.7.1
 ======
 

--- a/python/lsst/ts/MTMount/mtmount_commander.py
+++ b/python/lsst/ts/MTMount/mtmount_commander.py
@@ -41,8 +41,8 @@ class RampArgs:
 
 
 class MTMountCommander(salobj.CscCommander):
-    def __init__(self):
-        super().__init__(name="NewMTMount")
+    def __init__(self, enable):
+        super().__init__(name="NewMTMount", enable=enable)
         # Remote for telemetry
         self.mtmount_remote = salobj.Remote(
             domain=self.remote.salinfo.domain, name="MTMount"


### PR DESCRIPTION
Call asyncio.create_subprocess_exec with separate arguments
rather than one argument that is a list of arguments.

Make sure self.mock_command_port is set to the port used.