### PR TITLE
Cherry-pick DM-28362 ccw_only changes to the develop branch.

### DIFF
--- a/data/telemetry_map.yaml
+++ b/data/telemetry_map.yaml
@@ -38,6 +38,7 @@
 
 8:
 - cameraCableWrap
-- angleActual: angleActual
-  velocityActual: velocityActual
+- angleActual: angle
+  velocityActual: speed
+  accelerationActual: acceleration
   timestamp: timestamp

--- a/data/telemetry_map.yaml
+++ b/data/telemetry_map.yaml
@@ -39,8 +39,5 @@
 8:
 - cameraCableWrap
 - angleActual: angleActual
-  angleSet: angleSet
   velocityActual: velocityActual
-  velocitySet: velocitySet
-  accelerationActual: accelerationActual
   timestamp: timestamp

--- a/data/telemetry_map.yaml
+++ b/data/telemetry_map.yaml
@@ -8,12 +8,12 @@
 
 6: # fields are in flux
 - azimuth
-- angleActual: angleActual
-  angleSet: angleSet
-  velocityActual: velocityActual
-  velocitySet: velocitySet
-  accelerationActual: accelerationActual
-  torqueActual: torqueActual
+- actualPosition: angleActual
+  demandPosition: angleSet
+  actualVelocity: velocityActual
+  demandVelocity: velocitySet
+  actualAcceleration: accelerationActual
+  actualTorque: torqueActual
   timestamp: timestamp
 
 5:
@@ -23,12 +23,12 @@
 
 15: # fields are in flux
 - elevation
-- angleActual: angleActual
-  angleSet: angleSet
-  velocityActual: velocityActual
-  velocitySet: velocitySet
-  accelerationActual: accelerationActual
-  torqueActual: torqueActual
+- actualPosition: angleActual
+  demandPosition: angleSet
+  actualVelocity: velocityActual
+  demandVelocity: velocitySet
+  actualAcceleration: accelerationActual
+  actualTorque: torqueActual
   timestamp: timestamp
 
 14:
@@ -38,7 +38,7 @@
 
 8:
 - cameraCableWrap
-- angleActual: angle
-  velocityActual: speed
-  accelerationActual: acceleration
+- actualPosition: angle
+  actualVelocity: speed
+  actualAcceleration: acceleration
   timestamp: timestamp

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,30 @@
 Version History
 ###############
 
+v0.13.0
+=======
+
+Changes:
+
+* Overhaul camera cable wrap control.
+  This requires ts_xml 7.2:
+
+    * Rename command ``disableCameraCableWrapTracking`` to ``disableCameraCableWrapFollowing``
+    * Rename command ``enableCameraCableWrapTracking`` to ``enableCameraCableWrapFollowing``.
+      Make that command wait until camera cable wrap tracking is enabled and fail if it cannot be.
+    * Output new event ``cameraCableWrapFollowing``.
+    * Simplify the ``cameraCableWrap`` telemetry schema;
+      the set position, set velocity and actual accleration cannot be set because the information is not available.
+    * Simplify the algorithm for following the camera rotator.
+      With recent improvements from Tekniker we can now directly use the rotator demand position and velocity as the camera cable wrap target
+      (or actual rotator position and velocity, if actual position is too different from demand position).
+    * Limit the camera cable wrap target velocity if the rotator demand velocity is larger than the cable wrap supports.
+    * Correctly handle lack of telemetry messages from the camera rotator.
+      Stop the camera cable wrap while waiting for rotator telemetry to resume.
+    * Add configuration parameter ``max_rotator_position_error``.
+
+* `MTMountCsc`: reset e-stops as part of going to enabled state.
+
 v0.12.1
 =======
 

--- a/python/lsst/ts/MTMount/communicator.py
+++ b/python/lsst/ts/MTMount/communicator.py
@@ -213,7 +213,7 @@ class Communicator(client_server_pair.ClientServerPair):
             print("Client connection closed at the other end")
             pass
         except Exception as e:
-            print(f"monitor_client_reader failed: {e}")
+            print(f"monitor_client_reader failed: {e!r}")
 
         await self.close_client()
         self.call_connect_callback()

--- a/python/lsst/ts/MTMount/constants.py
+++ b/python/lsst/ts/MTMount/constants.py
@@ -18,6 +18,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from lsst.ts.idl.enums.MTMount import AxisState, DriveState
 
 # Reply ports are one larger.
 EUI_COMMAND_PORT = 60005
@@ -30,3 +31,25 @@ TELEMETRY_PORT = 50035
 
 # We probably don't need this, because -1 means "all drives".
 MIRROR_COVER_DRIVES = (0, 1, 2, 3)
+
+# Axis state from the low-level controller: AxisState enum value.
+AxisStateDict = {
+    "Unknown": AxisState.UNKNOWN,
+    "Idle": AxisState.OFF,
+    "On Enable": AxisState.ENABLED,
+    "On DiscreteMove": AxisState.DISCRETE_MOVE,
+    "On JogMove": AxisState.JOG_MOVE,
+    "On Tracking": AxisState.TRACKING,
+    "On Stopping": AxisState.STOPPING,
+    "Fault": AxisState.FAULT,
+}
+
+# Drive state from the low-level controller: DriveState enum value.
+DriveStateDict = {
+    "Unknown": DriveState.UNKNOWN,
+    "Off": DriveState.OFF,
+    "Standstill": DriveState.STOPPED,
+    "Discrete Motion": DriveState.MOVING,
+    "Stopping": DriveState.STOPPING,
+    "Fault": DriveState.FAULT,
+}

--- a/python/lsst/ts/MTMount/enums.py
+++ b/python/lsst/ts/MTMount/enums.py
@@ -26,7 +26,6 @@ __all__ = [
     "EnabledState",
     "ReplyCode",
     "Source",
-    "SubsystemId",
     "TelemetryTopicId",
 ]
 
@@ -196,8 +195,8 @@ class DeviceId(enum.Enum):
     These are for mock devices. The values do not match
     anything in Tekniker's code.
 
-    We could use SubsystemId, instead, but that enum class includes entries
-    that have no POWER or RESET_ALARM commands.
+    We could use SubsystemId from ts_idl, instead, but that enum class
+    includes entries that have no POWER or RESET_ALARM commands.
     """
 
     ELEVATION_AXIS = enum.auto()
@@ -259,40 +258,12 @@ class Source(enum.IntEnum):
     PXI = 100
 
 
-class SubsystemId(enum.IntEnum):
-    """Subsystem ID numbers.
-
-    Used in errors and warnings.
-    """
-
-    AZIMUTH_AXIS = 100
-    AZIMUTH_DRIVE = 200
-    AZIMUTH_CABLE_WRAP = 300
-    ELEVATION_AXIS = 400
-    ELEVATION_DRIVE = 500
-    MAIN_POWER_SUPPLY = 600
-    ENCODER_INTERFACE_BOX = 700
-    OIL_SUPPLY_SYSTEM = 800
-    MIRROR_COVERS = 900
-    CAMERA_CABLE_WRAP = 1000
-    BALANCE = 1100
-    DEPLOYABLE_PLATFORM = 1200
-    CABINET = 1300
-    LOCKING_PINS = 1400
-    MIRROR_COVER_LOCKS = 1500
-    AZIMUTH_THERMAL = 1600
-    ELEVATION_THERMAL = 1700
-    INTERLOCK = 1800
-    TOP_END_CHILLER = 2200
-
-
 class TelemetryTopicId(enum.IntEnum):
     """Telemetry topic ID values.
 
     These must match the data in telemetry_map.yaml
     """
 
-    # All of these except CCW is a guess
     AZIMUTH = 6
     AZIMUTH_DRIVE = 5
     ELEVATION = 15

--- a/python/lsst/ts/MTMount/limits.py
+++ b/python/lsst/ts/MTMount/limits.py
@@ -71,6 +71,6 @@ LimitsDict = {
     ),
     # From LTS-218.
     enums.DeviceId.CAMERA_CABLE_WRAP: Limits(
-        min_position=-90, max_position=90, max_velocity=3.5, max_acceleration=1
+        min_position=-90, max_position=90, max_velocity=4.0, max_acceleration=1.5
     ),
 }

--- a/python/lsst/ts/MTMount/mock/controller.py
+++ b/python/lsst/ts/MTMount/mock/controller.py
@@ -198,7 +198,7 @@ class Controller:
         except asyncio.CancelledError:
             print("Mock TMA controller done")
         except Exception as e:
-            print(f"Mock TMA controller failed: {e}")
+            print(f"Mock TMA controller failed: {e!r}")
 
     def telemetry_connect_callback(self, server):
         """Called when a client connects to or disconnects from

--- a/python/lsst/ts/MTMount/mock/controller.py
+++ b/python/lsst/ts/MTMount/mock/controller.py
@@ -29,11 +29,11 @@ import signal
 
 from lsst.ts import salobj
 from lsst.ts import hexrotcomm
-from .. import constants
 from .. import commands
+from .. import communicator
+from .. import constants
 from .. import enums
 from .. import replies
-from .. import communicator
 
 # from . import device
 from .axis_device import AxisDevice
@@ -257,29 +257,12 @@ class Controller:
         device = self.device_dict[enums.DeviceId.CAMERA_CABLE_WRAP]
         actuator = device.actuator
         actual = actuator.path.at(tai)
-        kind = actuator.kind(tai)
-
-        if device.power_on:
-            drive_status = {
-                actuator.Kind.Stopped: "Standstill",
-                actuator.Kind.Tracking: "Discrete Motion",
-                actuator.Kind.Slewing: "Discrete Motion",
-                actuator.Kind.Stopping: "Stopping",
-            }.get(kind, "Unknown")
-        else:
-            drive_status = "Off"
 
         data_dict = dict(
             topicID=enums.TelemetryTopicId.CAMERA_CABLE_WRAP,
-            cCWStatus="Enabled" if device.power_on else "Off",
-            cCWStatusDrive1="Off",  # Only one drive is on; assume drive 2
-            cCWStatusDrive2=drive_status,
-            cCWAngle1=actual.position,
-            cCWAngle2=actual.position,
-            cCWSpeed1=actual.velocity,
-            cCWSpeed2=actual.velocity,
-            cCWCurrent1=0,
-            cCWCurrent2=0,
+            angle=actual.position,
+            speed=actual.velocity,
+            acceleration=actual.acceleration,
             timestamp=tai,
         )
         await self.write_telemetry(data_dict)

--- a/python/lsst/ts/MTMount/mtmount_commander.py
+++ b/python/lsst/ts/MTMount/mtmount_commander.py
@@ -44,7 +44,7 @@ class MTMountCommander(salobj.CscCommander):
         super().__init__(
             name="MTMount",
             enable=enable,
-            telemetry_fields_to_not_compare=("current", "timestamp",),
+            telemetry_fields_to_not_compare=("current", "timestamp"),
         )
         for command_to_ignore in ("abort", "setValue"):
             self.command_dict.pop(command_to_ignore, None)

--- a/python/lsst/ts/MTMount/mtmount_commander.py
+++ b/python/lsst/ts/MTMount/mtmount_commander.py
@@ -44,7 +44,7 @@ class MTMountCommander(salobj.CscCommander):
         super().__init__(
             name="MTMount",
             enable=enable,
-            telemetry_fields_to_not_compare=("current", "timestamp"),
+            telemetry_fields_to_not_compare=("current", "timestamp",),
         )
         for command_to_ignore in ("abort", "setValue"):
             self.command_dict.pop(command_to_ignore, None)
@@ -56,22 +56,6 @@ class MTMountCommander(salobj.CscCommander):
     @property
     def ramp_arg_names(self):
         return
-
-    def tel_cameraCableWrap_callback(self, data):
-        """Handle NaN values.
-        """
-        name = "cameraCableWrap"
-        prev_value_name = f"previous_tel_{name}"
-        public_dict = self.get_rounded_public_data(data)
-        trimmed_dict = {
-            name: str(value)  # use str to handle nan
-            for name, value in public_dict.items()
-            if name not in self.telemetry_fields_to_not_compare
-        }
-        if trimmed_dict != getattr(self, prev_value_name):
-            setattr(self, prev_value_name, trimmed_dict)
-            formatted_data = self.format_dict(public_dict)
-            self.output(f"{data.private_sndStamp:0.3f}: {name}: {formatted_data}")
 
     async def do_ramp(self, args):
         ramp_arg_info = RampArgs.__dataclass_fields__

--- a/python/lsst/ts/MTMount/mtmount_csc.py
+++ b/python/lsst/ts/MTMount/mtmount_csc.py
@@ -876,7 +876,7 @@ class MTMountCsc(salobj.ConfigurableCsc):
     async def do_moveToTarget(self, data):
         self.assert_enabled()
         await self.send_command(
-            commands.BothAxesMove(azimuth=data.azimuth, elevation=data.elevation,),
+            commands.BothAxesMove(azimuth=data.azimuth, elevation=data.elevation),
         )
 
     async def do_trackTarget(self, data):

--- a/python/lsst/ts/MTMount/mtmount_csc.py
+++ b/python/lsst/ts/MTMount/mtmount_csc.py
@@ -48,8 +48,12 @@ MOCK_CTRL_START_TIME = 20
 TELEMETRY_START_TIME = 30
 
 # Maximum time to wait for rotator telemetry (seconds).
-# Must be less than the maximum time the CCW waits for a tracking command
-# before going to FAULT.
+# Must be significantly greater than the interval between rotator
+# telemetry updates, which should not be longer than 0.2 seconds.
+# For minimum confusion when CCW following fails, this should also be
+# significantly less than the maximum time the low-level controller waits
+# for a tracking command, which is controlled by setting "Tracking Wait time
+# for check setpoint"; on 2020-02-01 the value was 5 seconds.
 ROTATOR_TELEMETRY_TIMEOUT = 1
 
 
@@ -293,7 +297,12 @@ class MTMountCsc(salobj.ConfigurableCsc):
             > self.config.max_rotator_position_error
         ):
             if not self.rotator_position_error_excessive:
-                self.log.warning("Excessive rotator demand-actual error; using actual")
+                self.log.warning(
+                    "Excessive rotator demand-actual position error; using actual. "
+                    f"Demand={rot_data.demandPosition:0.3f}; "
+                    f"actual={rot_data.actualPosition:0.3f}; "
+                    f"max_rotator_position_error={self.config.max_rotator_position_error} deg."
+                )
                 self.rotator_position_error_excessive = True
             desired_position = rot_data.actualPosition
             desired_velocity = rot_data.actualVelocity

--- a/python/lsst/ts/MTMount/mtmount_csc.py
+++ b/python/lsst/ts/MTMount/mtmount_csc.py
@@ -204,10 +204,6 @@ class MTMountCsc(salobj.ConfigurableCsc):
                 await self.send_command(
                     commands.AskForCommand(commander=enums.Source.CSC)
                 )
-                self.log.info(
-                    "Wait 1 second before sending any other commands, to work around a TMA bug."
-                )
-                await asyncio.sleep(1)
                 self.has_control = True
             except Exception as e:
                 raise salobj.ExpectedError(

--- a/python/lsst/ts/MTMount/mtmount_csc.py
+++ b/python/lsst/ts/MTMount/mtmount_csc.py
@@ -492,11 +492,8 @@ class MTMountCsc(salobj.ConfigurableCsc):
                 commands.CameraCableWrapPower(on=True),
             ]
             await self.send_commands(*power_on_commands)
-        except salobj.ExpectedError as e:
+        except Exception as e:
             self.log.error(f"Failed to power on one or more devices: {e!r}")
-            raise
-        except Exception:
-            self.log.exception("Failed to power on one or more devices")
             raise
         self.camera_cable_wrap_follow_start_task = asyncio.create_task(
             self.camera_cable_wrap_start_following()
@@ -558,11 +555,8 @@ class MTMountCsc(salobj.ConfigurableCsc):
                 return await self._basic_send_command(command=command)
         except ConnectionResetError:
             raise
-        except salobj.ExpectedError as e:
-            self.log.error(f"Failed to send command {command}: {e!r}")
-            raise
-        except Exception:
-            self.log.exception(f"Failed to send command {command}")
+        except Exception as e:
+            self.log.exception(f"Failed to send command {command}: {e!r}")
             raise
 
     async def _basic_send_command(self, command):
@@ -626,17 +620,12 @@ class MTMountCsc(salobj.ConfigurableCsc):
         except ConnectionResetError:
             if future is not None:
                 future.setnoack("Connection lost")
-        except salobj.ExpectedError as e:
-            self.log.error(f"send_commands failed: {e!r}")
-            # The future is probably done, but in case not...
-            if future is not None:
-                future.setnoack(f"send_commands failed: {e!r}")
-            raise
         except Exception as e:
-            self.log.exception("send_commands failed")
+            err_msg = f"send_commands failed: {e!r}"
+            self.log.exception(err_msg)
             # The future is probably done, but in case not...
             if future is not None:
-                future.setnoack(f"send_commands failed: {e!r}")
+                future.setnoack(err_msg)
             raise
 
     def terminate_background_processes(self):
@@ -679,12 +668,13 @@ class MTMountCsc(salobj.ConfigurableCsc):
             self.log.info("Camera cable wrap following canceled before it starts")
             self.evt_cameraCableWrapFollowing.set_put(enabled=False)
             raise
-        except salobj.ExpectedError as e:
-            self.log.error(f"Camera cable wrap tracking could not be enabled: {e!r}")
-            self.evt_cameraCableWrapFollowing.set_put(enabled=False)
-            raise
-        except Exception:
-            self.log.exception("Camera cable wrap tracking could not be enabled")
+        except Exception as e:
+            if isinstance(e, salobj.ExpectedError):
+                self.log.error(
+                    f"Camera cable wrap tracking could not be enabled: {e!r}"
+                )
+            else:
+                self.log.exception("Camera cable wrap tracking could not be enabled")
             self.evt_cameraCableWrapFollowing.set_put(enabled=False)
             raise
 

--- a/python/lsst/ts/MTMount/mtmount_csc.py
+++ b/python/lsst/ts/MTMount/mtmount_csc.py
@@ -617,6 +617,9 @@ class MTMountCsc(salobj.ConfigurableCsc):
                     position=position, velocity=velocity, tai=tai,
                 )
                 await self.send_command(command)
+                self.evt_cameraCableWrapTarget.set_put(
+                    position=position, velocity=velocity, taiTime=tai
+                )
 
         except asyncio.CancelledError:
             self.log.info("Camera cable wrap control ends")

--- a/python/lsst/ts/MTMount/mtmount_csc.py
+++ b/python/lsst/ts/MTMount/mtmount_csc.py
@@ -151,8 +151,9 @@ class MTMountCsc(salobj.ConfigurableCsc):
 
         self.monitor_telemetry_client_task = salobj.make_done_future()
 
-        # Task for self.camera_cable_wrap_loop
-        self.camera_cable_wrap_task = salobj.make_done_future()
+        # Tasks for camera cable wrap following the rotator
+        self.camera_cable_wrap_follow_start_task = salobj.make_done_future()
+        self.camera_cable_wrap_follow_loop_task = salobj.make_done_future()
 
         # Task for self.read_loop
         self.read_loop_task = salobj.make_done_future()
@@ -461,15 +462,16 @@ class MTMountCsc(salobj.ConfigurableCsc):
         except Exception:
             self.log.exception("Failed to power on one or more devices")
             raise
-        if self.camera_cable_wrap_task.done():
-            self.camera_cable_wrap_task = asyncio.create_task(
-                self.camera_cable_wrap_loop()
-            )
+        self.camera_cable_wrap_follow_start_task = asyncio.create_task(
+            self.camera_cable_wrap_start_following()
+        )
+        await self.camera_cable_wrap_follow_start_task
 
     async def disable_devices(self):
         self.log.info("Disable devices")
         self.enable_task.cancel()
-        self.camera_cable_wrap_task.cancel()
+        self.camera_cable_wrap_follow_start_task.cancel()
+        self.camera_cable_wrap_follow_loop_task.cancel()
         if not self.connected:
             return
         for command in [
@@ -619,9 +621,43 @@ class MTMountCsc(salobj.ConfigurableCsc):
             self.telemetry_client_process.terminate()
             self.telemetry_client_process = None
 
-    async def camera_cable_wrap_loop(self):
-        self.log.info("Camera cable wrap control begins")
-        await self.send_command(commands.CameraCableWrapEnableTracking(on=True))
+    async def camera_cable_wrap_start_following(self):
+        """Make the camera cable wrap start following the camera rotator.
+
+        Camera cable wrap following is divided into two tasks so that the
+        enableCameraCableWrapFollowing command can succeed or fail
+        if following is likely or unlikely to work.
+
+        This method enables camera cable wrap tracking,
+        waits for that command to succeed or fail,
+        and if it succeeds, starts the camera cable wrap following loop.
+        """
+        self.camera_cable_wrap_follow_loop_task.cancel()
+        try:
+            await self.send_command(commands.CameraCableWrapEnableTracking(on=True))
+            self.camera_cable_wrap_follow_loop_task = asyncio.create_task(
+                self._camera_cable_wrap_follow_loop()
+            )
+            self.evt_cameraCableWrapFollowing.set_put(enabled=True, force_output=True)
+        except asyncio.CancelledError:
+            self.log.info("Camera cable wrap following canceled before it starts")
+            raise
+        except salobj.ExpectedError as e:
+            self.log.error(f"Camera cable wrap tracking could not be enabled: {e}")
+            raise
+        except Exception:
+            self.log.exception("Camera cable wrap tracking could not be enabled")
+            raise
+        finally:
+            self.evt_cameraCableWrapFollowing.set_put(enabled=False)
+
+    async def _camera_cable_wrap_follow_loop(self):
+        """Implement the camera cable wrap following the camera rotator.
+
+        This should be called by camera_cable_wrap_start_following.
+        Camera cable wrap tracking must be enabled before this is called.
+        """
+        self.log.info("Camera cable wrap following begins")
         try:
             while True:
                 position_velocity_tai = await self.get_camera_cable_wrap_demand()
@@ -638,14 +674,13 @@ class MTMountCsc(salobj.ConfigurableCsc):
                 )
 
         except asyncio.CancelledError:
-            self.log.info("Camera cable wrap control ends")
+            self.log.info("Camera cable wrap following ends")
         except salobj.ExpectedError as e:
-            self.log.error(f"Camera cable wrap control failed: {e}")
+            self.log.error(f"Camera cable wrap following failed: {e}")
         except Exception:
-            self.log.exception("Camera cable wrap control failed")
+            self.log.exception("Camera cable wrap following failed")
         finally:
-            self.last_rotator_position = None
-            self.last_rotator_time = None
+            self.evt_cameraCableWrapFollowing.set_put(enabled=False)
 
     async def configure(self, config):
         self.config = config
@@ -741,6 +776,7 @@ class MTMountCsc(salobj.ConfigurableCsc):
 
     async def start(self):
         await asyncio.gather(self.rotator.start_task, self.mtmount_remote.start_task)
+        self.evt_cameraCableWrapFollowing.set_put(enabled=False)
         await super().start()
         self.log.info("Started")
 
@@ -778,17 +814,19 @@ class MTMountCsc(salobj.ConfigurableCsc):
             commands.MirrorCoverLocksPower(on=False),
         )
 
-    async def do_disableCameraCableWrapTracking(self, data):
+    async def do_disableCameraCableWrapFollowing(self, data):
         self.assert_enabled()
-        self.camera_cable_wrap_task.cancel()
+        self.camera_cable_wrap_follow_start_task.cancel()
+        self.camera_cable_wrap_follow_loop_task.cancel()
         await self.send_command(commands.CameraCableWrapStop())
 
-    async def do_enableCameraCableWrapTracking(self, data):
+    async def do_enableCameraCableWrapFollowing(self, data):
         self.assert_enabled()
-        if self.camera_cable_wrap_task.done():
-            self.camera_cable_wrap_task = asyncio.create_task(
-                self.camera_cable_wrap_loop()
+        if self.camera_cable_wrap_follow_loop_task.done():
+            self.camera_cable_wrap_follow_start_task = asyncio.create_task(
+                self.camera_cable_wrap_start_following()
             )
+            await self.camera_cable_wrap_follow_start_task
 
     async def do_moveToTarget(self, data):
         self.assert_enabled()

--- a/python/lsst/ts/MTMount/mtmount_csc.py
+++ b/python/lsst/ts/MTMount/mtmount_csc.py
@@ -216,7 +216,7 @@ class MTMountCsc(salobj.ConfigurableCsc):
                 self.has_control = True
             except Exception as e:
                 raise salobj.ExpectedError(
-                    f"The CSC was not allowed to command the mount: {e}"
+                    f"The CSC was not allowed to command the mount: {e!r}"
                 )
 
         self.enable_task.cancel()
@@ -239,7 +239,7 @@ class MTMountCsc(salobj.ConfigurableCsc):
                 self.has_control = True
             except Exception as e:
                 self.log.warning(
-                    f"The CSC was not able to give up command of the mount: {e}"
+                    f"The CSC was not able to give up command of the mount: {e!r}"
                 )
         finally:
             self.has_control = False
@@ -360,7 +360,7 @@ class MTMountCsc(salobj.ConfigurableCsc):
                     self.log.exception(err_msg)
                     self.fault(
                         code=enums.CscErrorCode.MOCK_CONTROLLER_ERROR,
-                        report=f"{err_msg}: {e}",
+                        report=f"{err_msg}: {e!r}",
                     )
                     return
                 else:
@@ -399,7 +399,7 @@ class MTMountCsc(salobj.ConfigurableCsc):
             f"at client_host={client_host}, command_port={command_port}"
             self.log.exception(err_msg)
             self.fault(
-                code=enums.CscErrorCode.COULD_NOT_CONNECT, report=f"{err_msg}: {e}"
+                code=enums.CscErrorCode.COULD_NOT_CONNECT, report=f"{err_msg}: {e!r}"
             )
             return
 
@@ -418,7 +418,8 @@ class MTMountCsc(salobj.ConfigurableCsc):
             err_msg = f"Could not start MTMount telemetry client with {cmdstr!r}"
             self.log.exception(err_msg)
             self.fault(
-                code=enums.CscErrorCode.TELEMETRY_CLIENT_ERROR, report=f"{err_msg}: {e}"
+                code=enums.CscErrorCode.TELEMETRY_CLIENT_ERROR,
+                report=f"{err_msg}: {e!r}",
             )
             return
         try:
@@ -477,7 +478,9 @@ class MTMountCsc(salobj.ConfigurableCsc):
                 try:
                     await self.send_command(reset_command, do_lock=False)
                 except Exception as e:
-                    self.log.warning(f"Command {reset_command} failed; continuing: {e}")
+                    self.log.warning(
+                        f"Command {reset_command} failed; continuing: {e!r}"
+                    )
 
             power_on_commands = [
                 commands.TopEndChillerPower(on=True),
@@ -490,7 +493,7 @@ class MTMountCsc(salobj.ConfigurableCsc):
             ]
             await self.send_commands(*power_on_commands)
         except salobj.ExpectedError as e:
-            self.log.error(f"Failed to power on one or more devices: {e}")
+            self.log.error(f"Failed to power on one or more devices: {e!r}")
             raise
         except Exception:
             self.log.exception("Failed to power on one or more devices")
@@ -517,7 +520,7 @@ class MTMountCsc(salobj.ConfigurableCsc):
             try:
                 await self.send_command(command, do_lock=False)
             except Exception as e:
-                self.log.warning(f"Command {command} failed; continuing: {e}")
+                self.log.warning(f"Command {command} failed; continuing: {e!r}")
 
         self.evt_axesInPosition.set_put(azimuth=False, elevation=False)
 
@@ -556,7 +559,7 @@ class MTMountCsc(salobj.ConfigurableCsc):
         except ConnectionResetError:
             raise
         except salobj.ExpectedError as e:
-            self.log.error(f"Failed to send command {command}: {e}")
+            self.log.error(f"Failed to send command {command}: {e!r}")
             raise
         except Exception:
             self.log.exception(f"Failed to send command {command}")
@@ -624,16 +627,16 @@ class MTMountCsc(salobj.ConfigurableCsc):
             if future is not None:
                 future.setnoack("Connection lost")
         except salobj.ExpectedError as e:
-            self.log.error(f"send_commands failed: {e}")
+            self.log.error(f"send_commands failed: {e!r}")
             # The future is probably done, but in case not...
             if future is not None:
-                future.setnoack(f"send_commands failed: {e}")
+                future.setnoack(f"send_commands failed: {e!r}")
             raise
         except Exception as e:
             self.log.exception("send_commands failed")
             # The future is probably done, but in case not...
             if future is not None:
-                future.setnoack(f"send_commands failed: {e}")
+                future.setnoack(f"send_commands failed: {e!r}")
             raise
 
     def terminate_background_processes(self):
@@ -677,7 +680,7 @@ class MTMountCsc(salobj.ConfigurableCsc):
             self.evt_cameraCableWrapFollowing.set_put(enabled=False)
             raise
         except salobj.ExpectedError as e:
-            self.log.error(f"Camera cable wrap tracking could not be enabled: {e}")
+            self.log.error(f"Camera cable wrap tracking could not be enabled: {e!r}")
             self.evt_cameraCableWrapFollowing.set_put(enabled=False)
             raise
         except Exception:
@@ -729,7 +732,7 @@ class MTMountCsc(salobj.ConfigurableCsc):
         except asyncio.CancelledError:
             self.log.info("Camera cable wrap following ends")
         except salobj.ExpectedError as e:
-            self.log.error(f"Camera cable wrap following failed: {e}")
+            self.log.error(f"Camera cable wrap following failed: {e!r}")
         except Exception:
             self.log.exception("Camera cable wrap following failed")
         finally:
@@ -814,7 +817,7 @@ class MTMountCsc(salobj.ConfigurableCsc):
                         self.log.exception(err_msg)
                         self.fault(
                             code=enums.CscErrorCode.INTERNAL_ERROR,
-                            report=f"{err_msg}: {e}",
+                            report=f"{err_msg}: {e!r}",
                         )
                     else:
                         self.fault(

--- a/python/lsst/ts/MTMount/mtmount_csc.py
+++ b/python/lsst/ts/MTMount/mtmount_csc.py
@@ -605,6 +605,7 @@ class MTMountCsc(salobj.ConfigurableCsc):
 
     async def camera_cable_wrap_loop(self):
         self.log.info("Camera cable wrap control begins")
+        await self.send_command(commands.CameraCableWrapEnableTracking(on=True))
         try:
             while True:
                 position_velocity_tai = await self.get_camera_cable_wrap_demand()
@@ -763,7 +764,6 @@ class MTMountCsc(salobj.ConfigurableCsc):
 
     async def do_enableCameraCableWrapTracking(self, data):
         self.assert_enabled()
-        await self.send_command(commands.CameraCableWrapEnableTracking(on=True))
         if self.camera_cable_wrap_task.done():
             self.camera_cable_wrap_task = asyncio.create_task(
                 self.camera_cable_wrap_loop()

--- a/python/lsst/ts/MTMount/mtmount_csc.py
+++ b/python/lsst/ts/MTMount/mtmount_csc.py
@@ -47,6 +47,11 @@ MAX_ROTATOR_APPLICATION_GAP = 1.0
 MOCK_CTRL_START_TIME = 20
 TELEMETRY_START_TIME = 30
 
+# Maximum time to wait for rotator telemetry (seconds).
+# Must be less than the maximum time the CCW waits for a tracking command
+# before going to FAULT.
+ROTATOR_TELEMETRY_TIMEOUT = 1
+
 
 class MTMountCsc(salobj.ConfigurableCsc):
     """MTMount CSC
@@ -269,9 +274,16 @@ class MTMountCsc(salobj.ConfigurableCsc):
             Desired camera cable wrap time (TAI unix seconds).
             This will be ``config.camera_cable_wrap_advance_time``
             seconds in the future.
+
+        Raises
+        ------
+        asyncio.TimeoutError
+            If data not seen in ROTATOR_TELEMETRY_TIMEOUT seconds.
         """
 
-        rot_data = await self.rotator.tel_rotation.next(flush=True)
+        rot_data = await self.rotator.tel_rotation.next(
+            flush=True, timeout=ROTATOR_TELEMETRY_TIMEOUT
+        )
 
         desired_tai = salobj.current_tai() + self.config.camera_cable_wrap_advance_time
         dt = rot_data.timestamp - desired_tai
@@ -653,15 +665,16 @@ class MTMountCsc(salobj.ConfigurableCsc):
             self.evt_cameraCableWrapFollowing.set_put(enabled=True, force_output=True)
         except asyncio.CancelledError:
             self.log.info("Camera cable wrap following canceled before it starts")
+            self.evt_cameraCableWrapFollowing.set_put(enabled=False)
             raise
         except salobj.ExpectedError as e:
             self.log.error(f"Camera cable wrap tracking could not be enabled: {e}")
+            self.evt_cameraCableWrapFollowing.set_put(enabled=False)
             raise
         except Exception:
             self.log.exception("Camera cable wrap tracking could not be enabled")
-            raise
-        finally:
             self.evt_cameraCableWrapFollowing.set_put(enabled=False)
+            raise
 
     async def _camera_cable_wrap_follow_loop(self):
         """Implement the camera cable wrap following the camera rotator.
@@ -671,11 +684,29 @@ class MTMountCsc(salobj.ConfigurableCsc):
         """
         self.log.info("Camera cable wrap following begins")
         self.rotator_position_error_excessive = False
+        paused = False
         try:
             while True:
-                position_velocity_tai = await self.get_camera_cable_wrap_demand()
-                if position_velocity_tai is None:
-                    return
+                try:
+                    position_velocity_tai = await self.get_camera_cable_wrap_demand()
+                except asyncio.TimeoutError:
+                    if not paused:
+                        paused = True
+                        self.log.warning(
+                            "Rotator data not available; stopping the camera "
+                            "cable wrap until rotator data is available"
+                        )
+                        await self.send_command(commands.CameraCableWrapStop())
+                    continue
+                if paused:
+                    paused = False
+                    self.log.info(
+                        "Rotator data received; resume making "
+                        "the camera cable wrap follow the rotator"
+                    )
+                    await self.send_command(
+                        commands.CameraCableWrapEnableTracking(on=True)
+                    )
                 position, velocity, tai = position_velocity_tai
 
                 command = commands.CameraCableWrapTrack(
@@ -791,7 +822,6 @@ class MTMountCsc(salobj.ConfigurableCsc):
         await asyncio.gather(self.rotator.start_task, self.mtmount_remote.start_task)
         self.evt_cameraCableWrapFollowing.set_put(enabled=False)
         await super().start()
-        self.log.info("Started")
 
     async def do_clearError(self, data):
         self.assert_enabled()

--- a/python/lsst/ts/MTMount/telemetry_client.py
+++ b/python/lsst/ts/MTMount/telemetry_client.py
@@ -184,7 +184,7 @@ class TelemetryClient:
         except asyncio.CancelledError:
             print("MTMount telemetry client done")
         except Exception as e:
-            print(f"MTMount telemetry client failed: {e}")
+            print(f"MTMount telemetry client failed: {e!r}")
 
     async def start(self):
         """Connect to the telemetry port and start the read loop.
@@ -323,9 +323,6 @@ class TelemetryClient:
         else:
             llv_data["angleActual"] = llv_data["cCWAngle2"]
             llv_data["velocityActual"] = llv_data["cCWSpeed2"]
-        llv_data["accelerationActual"] = math.nan
-        llv_data["angleSet"] = math.nan
-        llv_data["velocitySet"] = math.nan
 
     def _preprocess_elevationDrives(self, llv_data):
         """Preprocess status for the tel_elevationDrives topic."""

--- a/python/lsst/ts/MTMount/telemetry_client.py
+++ b/python/lsst/ts/MTMount/telemetry_client.py
@@ -20,8 +20,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 __all__ = [
-    "AxisStateDict",
-    "DriveStateDict",
     "TelemetryTopicHandler",
     "TelemetryClient",
 ]
@@ -35,27 +33,8 @@ import pathlib
 
 import yaml
 
-from lsst.ts.idl.enums.MTMount import AxisState, DriveState
 from lsst.ts import salobj
 from . import constants
-
-
-AxisStateDict = {
-    "Unknown": AxisState.UNKNOWN,
-    "Off": AxisState.OFF,
-    "Enabled": AxisState.ENABLED,
-    "Fault": AxisState.FAULT,
-}
-
-
-DriveStateDict = {
-    "Unknown": DriveState.UNKNOWN,
-    "Off": DriveState.OFF,
-    "Standstill": DriveState.STOPPED,
-    "Discrete Motion": DriveState.MOVING,
-    "Stopping": DriveState.STOPPING,
-    "Fault": DriveState.FAULT,
-}
 
 
 class TelemetryTopicHandler:
@@ -279,50 +258,11 @@ class TelemetryClient:
                 llv_data.pop(f"{key}{n}", math.nan) for n in range(1, ndrives + 1)
             ]
 
-    def _convert_drive_states(self, llv_data, key, ndrives):
-        """Convert drive state strings.
-
-        Parameters
-        ----------
-        llv_data : dict
-            Data from the low-level controller. Modified in place.
-        key : str
-            Prefix for named items; one of "azStatusDrive",
-            "cCWStatusDrive", or "elStatusDrive".
-        ndrives : int
-            The number of drives.
-        """
-        llv_data[key] = [
-            DriveStateDict.get(llv_data.pop(f"{key}{n}", "Unknown"), DriveState.UNKNOWN)
-            for n in range(1, ndrives + 1)
-        ]
-
     def _preprocess_azimuthDrives(self, llv_data):
         """Preprocess status for the tel_azimuthDrives topic."""
         self._convert_drive_measurements(
             llv_data=llv_data, keys=["azCurrent"], ndrives=16
         )
-
-    def _preprocess_cameraCableWrap(self, llv_data):
-        """Preprocess status for the tel_cameraCableWrap topic.
-
-        This method is rather complicated because the data
-        output by the CCW as of 2021-01-11 does not look much like
-        the data that will be output by the final TMA.
-        For now the CCW outputs cCWAngle1, cCWAngle2, cCWSpeed1, and cCWSpeed2,
-        where the 1 values are only valid if drive 1 is on,
-        and the 2 values are only valid if drive 2 is on.
-        The positions are moderately close, the speeds less so.
-        For now I report the 1 values if drive 1 is on and the 2 values
-        otherwise, because we tend to use drive 2.
-        """
-        drive_state1 = llv_data.get("cCWStatusDrive1", None)
-        if drive_state1 in self.on_drive_states:
-            llv_data["angleActual"] = llv_data["cCWAngle1"]
-            llv_data["velocityActual"] = llv_data["cCWSpeed1"]
-        else:
-            llv_data["angleActual"] = llv_data["cCWAngle2"]
-            llv_data["velocityActual"] = llv_data["cCWSpeed2"]
 
     def _preprocess_elevationDrives(self, llv_data):
         """Preprocess status for the tel_elevationDrives topic."""

--- a/python/lsst/ts/MTMount/telemetry_client.py
+++ b/python/lsst/ts/MTMount/telemetry_client.py
@@ -153,7 +153,7 @@ class TelemetryClient:
             f"host={namespace.host}; "
             f"port={namespace.port}"
         )
-        telemetry_client = cls(host=namespace.host, port=namespace.port,)
+        telemetry_client = cls(host=namespace.host, port=namespace.port)
         telemetry_client.log.setLevel(namespace.loglevel)
         try:
             print("MTMount telemetry client starting")

--- a/python/lsst/ts/MTMount/tma_commander.py
+++ b/python/lsst/ts/MTMount/tma_commander.py
@@ -286,7 +286,7 @@ ask_for_command 1
                     else:
                         await self.handle_command(cmd_name, args)
                 except Exception as e:
-                    print(f"Command {cmd_name} failed: {e}")
+                    print(f"Command {cmd_name} failed: {e!r}")
                     print(traceback.format_exc())
                     continue
         finally:

--- a/python/lsst/ts/MTMount/tma_commander.py
+++ b/python/lsst/ts/MTMount/tma_commander.py
@@ -32,15 +32,16 @@ For more information:
 
 tma_commander.py --help
 """
+__all__ = ["TmaCommander"]
 
 import argparse
 import asyncio
 import logging
-import math
 import sys
 import traceback
 
 from lsst.ts import salobj
+from lsst.ts import simactuators
 
 from . import constants
 from . import command_futures
@@ -129,7 +130,7 @@ class TmaCommander:
         self.tracking_task = salobj.make_done_future()
 
         # Dict of command_id: CommandFuture
-        self.command_dict = dict()
+        self.command_futures_dict = dict()
 
         self.simulator = None
         if simulate:
@@ -199,9 +200,9 @@ TMA Commands (omit the tai argument, if shown):
 {self.get_command_help()}
 
 Other commands:
-ccw_ramp start_position end_position velocity  # make CCW track a ramp
-ccw_sine start_position amplitude  # make CCW track one cycle of a sine wave
-stop  # stop ccw_ramp or ccw_sine
+ccw_ramp start_position end_position speed  # make CCW track a ramp
+ccw_cosine center_position amplitude max_speed # make CCW track one cycle of a cosine wave
+stop  # stop ccw_ramp or ccw_cosine
 exit  # Exit from this commander
 help  # Print this help
 
@@ -243,9 +244,9 @@ ask_for_command 1
             await self.stop_tracking(verbose=False)
             self.read_loop_task.cancel()
             self.command_loop_task.cancel()
-            while self.command_dict:
-                command = self.command_dict.popitem()[1]
-                command.setdone()
+            while self.command_futures_dict:
+                cmd_futures = self.command_futures_dict.popitem()[1]
+                cmd_futures.setdone()
             if self.simulator is not None:
                 await self.simulator.close()
             await self.communicator.close()
@@ -278,8 +279,8 @@ ask_for_command 1
                         print(self.help_text)
                     elif cmd_name == "ccw_ramp":
                         await self.start_ccw_ramp(args)
-                    elif cmd_name == "ccw_sine":
-                        await self.start_ccw_sine(args)
+                    elif cmd_name == "ccw_cosine":
+                        await self.start_ccw_cosine(args)
                     elif cmd_name == "stop":
                         await self.stop_tracking(verbose=True)
                     else:
@@ -379,20 +380,20 @@ ask_for_command 1
                 # with do_wait=True are put in the command dict).
                 if isinstance(reply, replies.AckReply):
                     # Command acknowledged. Set timeout but leave
-                    # futures in command_dict.
-                    futures = self.command_dict.get(reply.sequence_id, None)
-                    if futures is not None:
-                        futures.setack(reply.timeout_ms / 100.0)
+                    # cmd_futures in command_futures_dict.
+                    cmd_futures = self.command_futures_dict.get(reply.sequence_id, None)
+                    if cmd_futures is not None:
+                        cmd_futures.setack(reply.timeout_ms / 100.0)
                 elif isinstance(reply, replies.NoAckReply):
-                    # Command failed. Pop the command_dict entry
+                    # Command failed. Pop the command_futures_dict entry
                     # and report failure.
-                    futures = self.command_dict.pop(reply.sequence_id, None)
-                    if futures is not None:
-                        futures.setnoack(reply.explanation)
+                    cmd_futures = self.command_futures_dict.pop(reply.sequence_id, None)
+                    if cmd_futures is not None:
+                        cmd_futures.setnoack(reply.explanation)
                 elif isinstance(reply, replies.DoneReply):
-                    futures = self.command_dict.pop(reply.sequence_id, None)
-                    if futures is not None:
-                        futures.setdone()
+                    cmd_futures = self.command_futures_dict.pop(reply.sequence_id, None)
+                    if cmd_futures is not None:
+                        cmd_futures.setdone()
 
         except asyncio.CancelledError:
             pass
@@ -407,7 +408,7 @@ ask_for_command 1
         """Start the camera cable wrap tracking a linear ramp.
         """
         self.tracking_task.cancel()
-        arg_names = ("start_position", "end_position", "velocity")
+        arg_names = ("start_position", "end_position", "speed")
         if len(args) != len(arg_names):
             arg_names_str = ", ".join(arg_names)
             raise ValueError(
@@ -417,11 +418,11 @@ ask_for_command 1
         kwargs = {name: arg for name, arg in zip(arg_names, args)}
         self.tracking_task = asyncio.ensure_future(self._ccw_ramp(**kwargs))
 
-    async def start_ccw_sine(self, args):
-        """Start the camera cable wrap tracking one cycle of a sine wave.
+    async def start_ccw_cosine(self, args):
+        """Start the camera cable wrap tracking one cycle of a cosine wave.
         """
         self.tracking_task.cancel()
-        arg_names = ("start_position", "amplitude", "period")
+        arg_names = ("center_position", "amplitude", "max_speed")
         if len(args) != len(arg_names):
             arg_names_str = ", ".join(arg_names)
             raise ValueError(
@@ -429,7 +430,7 @@ ask_for_command 1
             )
         args = [float(arg) for arg in args]
         kwargs = {name: arg for name, arg in zip(arg_names, args)}
-        self.tracking_task = asyncio.ensure_future(self._ccw_sine(**kwargs))
+        self.tracking_task = asyncio.ensure_future(self._ccw_cosine(**kwargs))
 
     async def stop_tracking(self, verbose):
         if not self.tracking_task.done():
@@ -446,33 +447,33 @@ ask_for_command 1
         If do_wait true then wait for the command to finish.
         """
         print(f"Write {command}")
-        if command.sequence_id in self.command_dict:
+        if command.sequence_id in self.command_futures_dict:
             raise RuntimeError(
-                f"Bug! Duplicate sequence_id {command.sequence_id} in command_dict"
+                f"Bug! Duplicate sequence_id {command.sequence_id} in command_futures_dict"
             )
         await self.communicator.write(command)
         if not do_wait:
             return
 
-        futures = command_futures.CommandFutures()
-        self.command_dict[command.sequence_id] = futures
-        await asyncio.wait_for(futures.ack, ACK_TIMEOUT)
+        cmd_futures = command_futures.CommandFutures()
+        self.command_futures_dict[command.sequence_id] = cmd_futures
+        await asyncio.wait_for(cmd_futures.ack, ACK_TIMEOUT)
         if command.command_code in commands.AckOnlyCommandCodes:
             # This command only receives an Ack; mark it done.
-            futures.done.set_result(None)
+            cmd_futures.done.set_result(None)
         else:
             try:
                 await asyncio.wait_for(
-                    futures.done, timeout=futures.timeout + TIMEOUT_BUFFER
+                    cmd_futures.done, timeout=cmd_futures.timeout + TIMEOUT_BUFFER
                 )
             except asyncio.TimeoutError:
-                self.command_dict.pop(command.sequence_id, None)
+                self.command_futures_dict.pop(command.sequence_id, None)
                 raise asyncio.TimeoutError(
-                    f"Timed out after {futures.timeout + TIMEOUT_BUFFER} seconds "
+                    f"Timed out after {cmd_futures.timeout + TIMEOUT_BUFFER} seconds "
                     f"waiting for the Done reply to {command}"
                 )
 
-    async def _ccw_ramp(self, start_position, end_position, velocity):
+    async def _ccw_ramp(self, start_position, end_position, speed):
         """Make the camera cable wrap track a linear ramp.
 
         Parameters
@@ -481,30 +482,28 @@ ask_for_command 1
             Starting position of ramp (deg).
         end_position : `float`
             Ending position of ramp (deg).
-        velocity : `float`
-            Velocity of motion along the ramp (deg/sec).
+        speed : `float`
+            Speed of motion along the ramp (deg/sec).
+            The sign is ignored.
         """
         try:
-            if velocity == 0:
-                raise ValueError(f"velocity {velocity} must be nonzero")
-            dt = (end_position - start_position) / velocity
-            if dt < 0:
-                raise ValueError(f"velocity {velocity} has the wrong sign")
-            print(
-                f"Tracking a ramp from {start_position} to {end_position} at velocity {velocity}; "
-                f"this will take {dt:0.2f} seconds"
+            ramp_generator = simactuators.RampGenerator(
+                start_positions=[start_position],
+                end_positions=[end_position],
+                speeds=[speed],
+                advance_time=TRACK_ADVANCE_TIME,
             )
-            dpos = velocity * TRACK_INTERVAL
-            nelts = int(dt / TRACK_INTERVAL)
+            print(
+                f"Tracking a ramp from {start_position} to {end_position} at speed {speed}; "
+                f"this will take {ramp_generator.duration:0.2f} seconds"
+            )
+
             await self.write_command(
                 commands.CameraCableWrapEnableTracking(on=True), do_wait=True
             )
-            for i in range(nelts):
-                position = start_position + i * dpos
+            for positions, velocities, tai in ramp_generator():
                 track_command = commands.CameraCableWrapTrack(
-                    position=position,
-                    velocity=velocity,
-                    tai=salobj.current_tai() + TRACK_ADVANCE_TIME,
+                    position=positions[0], velocity=velocities[0], tai=tai,
                 )
                 await self.write_command(track_command, do_wait=True)
                 await asyncio.sleep(TRACK_INTERVAL)
@@ -517,48 +516,46 @@ ask_for_command 1
             await asyncio.sleep(0.1)
             await self.write_command(commands.CameraCableWrapStop())
 
-    async def _ccw_sine(self, start_position, amplitude, period):
-        """Make the camera cable wrap track one cycle of a sine wave.
+    async def _ccw_cosine(self, center_position, amplitude, max_speed):
+        """Make the camera cable wrap track one cycle of a cosine wave.
 
-        The range of motion is period - amplitude to period + amplitude,
+        The range of motion is center_position +/- amplitude,
         plus whatever motion is required to slew to the path.
 
         Parameters
         ----------
-        start_position : `float`
-            Midpoint of sine wave (deg).
+        center_position : `float`
+            Midpoint of cosine wave (deg).
         amplitude : `float`
-            Amplitude of sine wave (deg).
-        period : `float`
-            Duration of motion: one full wave (sec).
+            Amplitude of cosine wave (deg).
+        max_speed : `float`
+            Maximum speed along the path (deg/sec).
         """
         try:
-            if period <= 0:
-                raise ValueError(f"period {period} must be positive")
-            print(
-                f"Tracking one cycle of a sine wave centered at {start_position} "
-                f"with amplitude {amplitude} and a period of {period}"
+            cosine_generator = simactuators.CosineGenerator(
+                center_positions=[center_position],
+                amplitudes=[amplitude],
+                max_speeds=[max_speed],
+                advance_time=TRACK_ADVANCE_TIME,
             )
-            nelts = int(period / TRACK_INTERVAL)
-            vmax = amplitude * 2 * math.pi / period
+            print(
+                f"Tracking one cycle of a cosine wave centered at {center_position} "
+                f"with amplitude {amplitude}; "
+                f"this will take {cosine_generator.duration:0.2f} seconds"
+            )
             await self.write_command(
                 commands.CameraCableWrapEnableTracking(on=True), do_wait=True
             )
-            for i in range(nelts):
-                angle_rad = 2 * math.pi * i / nelts
-                position = amplitude * math.sin(angle_rad) + start_position
-                velocity = vmax * math.cos(angle_rad)
+            for positions, velocities, tai in cosine_generator():
                 track_command = commands.CameraCableWrapTrack(
-                    position=position,
-                    velocity=velocity,
-                    tai=salobj.current_tai() + TRACK_ADVANCE_TIME,
+                    position=positions[0], velocity=velocities[0], tai=tai,
                 )
                 await self.write_command(track_command, do_wait=True)
                 await asyncio.sleep(TRACK_INTERVAL)
         except asyncio.CancelledError:
-            print("ccw_sine cancelled")
+            print("ccw_cosine cancelled")
         except Exception as e:
-            print(f"ccw_sine failed: {e!r}")
+            print(f"ccw_cosine failed: {e!r}")
         finally:
             # Wait a bit in case there is a tracking command to be acked.
             await asyncio.sleep(0.1)

--- a/schema/MTMount.yaml
+++ b/schema/MTMount.yaml
@@ -26,20 +26,29 @@ properties:
     exclusiveMinimum: 0
     default: 10
   camera_cable_wrap_advance_time:
-      description: >-
-        How far in advance of the current time to make the tai time field of camera cable wrap
-        tracking commands (sec). All tracking commands must sent to the low-level controller in advance,
-        so it can interpolate between pairs of tracking command. If a tracking command is late then
-        the controller will halt the axis. Set this value large enough that camera cable wrap
-        commands reliably arrive in time, despite variation in speed of the Python CSC.
-        Avoid making it much larger than required, because it introduces a delay in motion
-        of the camera cable wrap, which can cause too large an error between the camera rotator
-        and the camera cable wrap when the rotator is offset or slewed to a new field.
-      type: number
-      default: 0.02
+    description: >-
+      How far in advance of the current time to make the tai time field of camera cable wrap
+      tracking commands (sec). All tracking commands must sent to the low-level controller in advance,
+      so it can interpolate between pairs of tracking command. If a tracking command is late then
+      the controller will halt the axis. Set this value large enough that camera cable wrap
+      commands reliably arrive in time, despite variation in speed of the Python CSC.
+      Avoid making it much larger than required, because it introduces a delay in motion
+      of the camera cable wrap, which can cause too large an error between the camera rotator
+      and the camera cable wrap when the rotator is offset or slewed to a new field.
+    type: number
+    default: 0.02
+  max_rotator_position_error:
+    description: >-
+      The maximum difference (in degrees) between camera rotator actual position and demand position
+      beyond which the camera cable wrap will follow the camera rotator actual position and velocity,
+      rather than the usual demand position and velocity.
+    type: number
+    exclusiveMinimum: 0
+    default: 0.1
 required:
   - host
   - connection_timeout
   - ack_timeout
   - camera_cable_wrap_advance_time
+  - max_rotator_position_error
 additionalProperties: false

--- a/tests/test_communicator.py
+++ b/tests/test_communicator.py
@@ -28,6 +28,7 @@ import asynctest
 
 from lsst.ts import salobj
 from lsst.ts import MTMount
+from lsst.ts.idl.enums.MTMount import SubsystemId
 
 # Standard timeout for TCP/IP messages (sec).
 STD_TIMEOUT = 0.01
@@ -167,7 +168,7 @@ class CommunicatorTestCase(asynctest.TestCase):
             MTMount.replies.WarningReply(
                 active=True,
                 code=47,
-                subsystem=f"{MTMount.SubsystemId.MIRROR_COVERS}. MyTopVI/MyNextVI/MyNextNextVI",
+                subsystem=f"{SubsystemId.MIRROR_COVERS}. MyTopVI/MyNextVI/MyNextNextVI",
                 what="test warning",
                 description="Description of the warning",
             ),
@@ -175,7 +176,7 @@ class CommunicatorTestCase(asynctest.TestCase):
                 on=True,
                 active=False,
                 code=47,
-                subsystem=f"{MTMount.SubsystemId.MIRROR_COVERS}. MyTopVI/MyNextVI/MyNextNextVI",
+                subsystem=f"{SubsystemId.MIRROR_COVERS}. MyTopVI/MyNextVI/MyNextNextVI",
                 what="test error",
                 description="Description of the error",
             ),

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -236,9 +236,7 @@ class CscTestCase(salobj.BaseCscTestCase, asynctest.TestCase):
                 velocity = 0.1
                 tai0 = salobj.current_tai()
                 num_rotator_samples = 10
-                prev_position = None
                 previous_tai = 0
-                previous_delay = None
                 for i in range(num_rotator_samples):
                     tai = salobj.current_tai()
                     # Work around non-monotonic clocks, which are
@@ -266,19 +264,6 @@ class CscTestCase(salobj.BaseCscTestCase, asynctest.TestCase):
                         tai + self.csc.config.camera_cable_wrap_advance_time
                     )
                     self.assertLessEqual(command.tai - desired_command_tai, delay)
-                    self.assertAlmostEqual(command.position, position)
-                    if i == 0 or not self.csc.catch_up_mode:
-                        self.assertAlmostEqual(command.velocity, 0.0)
-                    else:
-                        nominal_dt = tai - previous_tai
-                        min_dt = nominal_dt - delay - previous_delay
-                        max_dt = nominal_dt + delay + previous_delay
-                        min_vel = (position - prev_position) / max_dt
-                        max_vel = (position - prev_position) / min_dt
-                        max_vel_error = max_vel - min_vel
-                        self.assertAlmostEqual(
-                            command.velocity, velocity, delta=max_vel_error
-                        )
 
                     # Check camera cable wrap telemetry;
                     # use a crude comparison because a new CCW tracking
@@ -295,9 +280,7 @@ class CscTestCase(salobj.BaseCscTestCase, asynctest.TestCase):
                     )
 
                     await asyncio.sleep(0.1)
-                    prev_position = position
                     previous_tai = tai
-                    previous_delay = delay
 
                 # Stop the camera cable wrap tracking loop.
                 await self.remote.cmd_disableCameraCableWrapTracking.start(

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -143,33 +143,36 @@ class CscTestCase(salobj.BaseCscTestCase, asynctest.TestCase):
             await self.assert_next_sample(
                 topic=self.remote.tel_azimuth,
                 flush=False,
-                angleActual=0,
-                angleSet=0,
-                velocityActual=0,
-                velocitySet=0,
-                accelerationActual=0,
+                actualPosition=0,
+                actualVelocity=0,
+                actualAcceleration=0,
+                actualTorque=0,
+                demandPosition=0,
+                demandVelocity=0,
             )
 
             data = await self.assert_next_sample(
                 topic=self.remote.tel_elevation,
                 flush=False,
-                velocitySet=0,
-                velocityActual=0,
-                accelerationActual=0,
+                actualVelocity=0,
+                actualAcceleration=0,
+                actualTorque=0,
+                demandVelocity=0,
             )
             min_elevation = (
                 MTMount.LimitsDict[MTMount.DeviceId.ELEVATION_AXIS]
                 .scaled()
                 .min_position
             )
-            self.assertAlmostEqual(data.angleSet, min_elevation)
-            self.assertAlmostEqual(data.angleActual, min_elevation)
+            self.assertAlmostEqual(data.demandPosition, min_elevation)
+            self.assertAlmostEqual(data.actualPosition, min_elevation)
 
             await self.assert_next_sample(
                 topic=self.remote.tel_cameraCableWrap,
                 flush=False,
-                angleActual=0,
-                velocityActual=0,
+                actualPosition=0,
+                actualVelocity=0,
+                actualAcceleration=0,
             )
 
     async def test_standard_state_transitions(self):
@@ -293,10 +296,15 @@ class CscTestCase(salobj.BaseCscTestCase, asynctest.TestCase):
                     )
                     actual_segment = ccw_actuator.path.at(tel_ccw_data.timestamp)
                     self.assertAlmostEqual(
-                        tel_ccw_data.angleActual, actual_segment.position, delta=0.1
+                        tel_ccw_data.actualPosition, actual_segment.position, delta=0.1
                     )
                     self.assertAlmostEqual(
-                        tel_ccw_data.velocityActual, actual_segment.velocity, delta=0.1
+                        tel_ccw_data.actualVelocity, actual_segment.velocity, delta=0.1
+                    )
+                    self.assertAlmostEqual(
+                        tel_ccw_data.actualAcceleration,
+                        actual_segment.acceleration,
+                        delta=0.1,
                     )
 
                     await asyncio.sleep(0.1)
@@ -589,19 +597,19 @@ class CscTestCase(salobj.BaseCscTestCase, asynctest.TestCase):
             )
             el_actual = elevation_actuator.path.at(tel_el_data.timestamp)
             el_target = elevation_actuator.target.at(tel_el_data.timestamp)
-            self.assertAlmostEqual(tel_el_data.angleSet, el_target.position)
-            self.assertAlmostEqual(tel_el_data.velocitySet, el_target.velocity)
-            self.assertAlmostEqual(tel_el_data.angleActual, el_actual.position)
-            self.assertAlmostEqual(tel_el_data.velocityActual, el_actual.velocity)
+            self.assertAlmostEqual(tel_el_data.demandPosition, el_target.position)
+            self.assertAlmostEqual(tel_el_data.demandVelocity, el_target.velocity)
+            self.assertAlmostEqual(tel_el_data.actualPosition, el_actual.position)
+            self.assertAlmostEqual(tel_el_data.actualVelocity, el_actual.velocity)
 
             tel_az_data = await self.remote.tel_azimuth.next(
                 flush=True, timeout=STD_TIMEOUT
             )
             az_actual = azimuth_actuator.path.at(tel_az_data.timestamp)
             az_target = azimuth_actuator.target.at(tel_az_data.timestamp)
-            self.assertAlmostEqual(tel_az_data.angleSet, az_target.position)
-            self.assertAlmostEqual(tel_az_data.velocitySet, az_target.velocity)
-            self.assertAlmostEqual(tel_az_data.angleActual, az_actual.position)
-            self.assertAlmostEqual(tel_az_data.velocityActual, az_actual.velocity)
+            self.assertAlmostEqual(tel_az_data.demandPosition, az_target.position)
+            self.assertAlmostEqual(tel_az_data.demandVelocity, az_target.velocity)
+            self.assertAlmostEqual(tel_az_data.actualPosition, az_actual.position)
+            self.assertAlmostEqual(tel_az_data.actualVelocity, az_actual.velocity)
 
             previous_tai = tai

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -538,7 +538,7 @@ class CscTestCase(salobj.BaseCscTestCase, asynctest.TestCase):
             # for each axis (resulting in two axesInPosition events)
             # or can be sent for both axes at the same time
             # (resulting in a single axesInPosition event).
-            data = await self.assert_next_sample(self.remote.evt_axesInPosition,)
+            data = await self.assert_next_sample(self.remote.evt_axesInPosition)
             self.assertIn(False, (data.azimuth, data.elevation))
             if True in (data.azimuth, data.elevation):
                 await self.assert_next_sample(

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -448,13 +448,18 @@ class CscTestCase(salobj.BaseCscTestCase, asynctest.TestCase):
             self.assertAlmostEqual(azimuth_pvt.velocity, 0)
             self.assertAlmostEqual(elevation_pvt.velocity, 0)
 
-            # Check that putting the CSC into STANDBY state
-            # sends the axes out of position
+            # Check that putting the CSC into STANDBY state sends the axes
+            # out of position (possibly one axis at a time)
             await self.remote.cmd_disable.start(timeout=STD_TIMEOUT)
             await self.remote.cmd_standby.start(timeout=STD_TIMEOUT)
-            await self.assert_next_sample(
-                self.remote.evt_axesInPosition, azimuth=False, elevation=False,
-            )
+            try:
+                await self.assert_next_sample(
+                    self.remote.evt_axesInPosition, azimuth=False, elevation=False,
+                )
+            except AssertionError:
+                await self.assert_next_sample(
+                    self.remote.evt_axesInPosition, azimuth=False, elevation=False,
+                )
 
     async def test_tracking(self):
         async with self.make_csc(initial_state=salobj.State.ENABLED):

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -222,7 +222,13 @@ class CscTestCase(salobj.BaseCscTestCase, asynctest.TestCase):
         )
 
     async def test_camera_cable_wrap_tracking(self):
-        async with self.make_csc(initial_state=salobj.State.ENABLED):
+        # Start the CSC in DISABLED state
+        # so we can get the rotator remote running
+        # before the camera cable wrap loop needs data from the rotator.
+        # (I tried constructing the rotator before the CSC
+        # but for some reason the CSC doesn't see data from the rotator
+        # when I do that).
+        async with self.make_csc(initial_state=salobj.State.DISABLED):
             await self.assert_next_sample(
                 self.remote.evt_cameraCableWrapFollowing, enabled=False
             )
@@ -230,16 +236,20 @@ class CscTestCase(salobj.BaseCscTestCase, asynctest.TestCase):
                 MTMount.DeviceId.CAMERA_CABLE_WRAP
             ]
             ccw_actuator = ccw_device.actuator
-            self.assertTrue(ccw_device.power_on)
-            self.assertTrue(ccw_device.enabled)
-
-            await self.assert_next_sample(
-                self.remote.evt_cameraCableWrapFollowing, enabled=True
-            )
-            self.assertTrue(ccw_device.tracking_enabled)
-            self.mock_controller.set_command_queue(maxsize=0)
+            self.assertFalse(ccw_device.power_on)
+            self.assertFalse(ccw_device.enabled)
 
             async with salobj.Controller(name="MTRotator") as rotator:
+                await self.remote.cmd_enable.start(timeout=STD_TIMEOUT)
+                self.assertTrue(ccw_device.power_on)
+                self.assertTrue(ccw_device.enabled)
+
+                await self.assert_next_sample(
+                    self.remote.evt_cameraCableWrapFollowing, enabled=True
+                )
+                self.assertTrue(ccw_device.tracking_enabled)
+                self.mock_controller.set_command_queue(maxsize=0)
+
                 self.assertTrue(self.mock_controller.command_queue.empty())
 
                 # Test regular tracking mode. CCW and MTRotator start in sync.
@@ -266,7 +276,6 @@ class CscTestCase(salobj.BaseCscTestCase, asynctest.TestCase):
                     )
                     command = await self.next_lowlevel_command()
                     delay = salobj.current_tai() - tai
-
                     self.assertEqual(
                         command.command_code,
                         MTMount.CommandCode.CAMERA_CABLE_WRAP_TRACK,

--- a/tests/test_mock_controller.py
+++ b/tests/test_mock_controller.py
@@ -480,18 +480,12 @@ class MockControllerTestCase(asynctest.TestCase):
             ccw_telem = await self.next_telemetry(
                 MTMount.TelemetryTopicId.CAMERA_CABLE_WRAP
             )
-            self.assertEqual(ccw_telem["cCWStatusDrive1"], "Off")
-            self.assertEqual(ccw_telem["cCWStatusDrive2"], "Off")
-            for brief_name in (
-                "Angle1",
-                "Angle2",
-                "Speed1",
-                "Speed2",
-                "Current1",
-                "Current2",
+            for name in (
+                "angle",
+                "speed",
+                "acceleration",
             ):
-                full_name = f"cCW{brief_name}"
-                self.assertEqual(ccw_telem[full_name], 0, msg=full_name)
+                self.assertEqual(ccw_telem[name], 0, msg=name)
             self.assertGreater(ccw_telem["timestamp"], tai0)
 
     async def test_tracking(self):

--- a/tests/test_mock_controller.py
+++ b/tests/test_mock_controller.py
@@ -64,10 +64,10 @@ class MockControllerTestCase(asynctest.TestCase):
 
         Parameters
         ----------
-    commander : `Source`, optional
-        Who initially has command. Defaults to `Source.CSC`,
-        so tests need not issue the ``ASK_FOR_COMMAND`` command
-        before issuing other commands.
+        commander : `Source`, optional
+            Who initially has command. Defaults to `Source.CSC`,
+            so tests need not issue the ``ASK_FOR_COMMAND`` command
+            before issuing other commands.
 
         Other special values:
 

--- a/tests/test_mock_controller.py
+++ b/tests/test_mock_controller.py
@@ -1,4 +1,4 @@
-# This file is part of ts_ATDomeTrajectory.
+# This file is part of ts_MTMount.
 #
 # Developed for the LSST Telescope and Site Systems.
 # This product includes software developed by the LSST Project

--- a/tests/test_mock_devices.py
+++ b/tests/test_mock_devices.py
@@ -78,7 +78,7 @@ class MockDevicesTestCase(asynctest.TestCase):
         try:
             timeout_task = do_method(command)
         except Exception as e:
-            print(f"command failed: {e}")
+            print(f"command failed: {e!r}")
             raise
 
         if timeout_task is None:
@@ -100,7 +100,7 @@ class MockDevicesTestCase(asynctest.TestCase):
                 self.fail(f"Command {command} succeeded but should_noack true")
         except Exception as e:
             if not should_noack:
-                self.fail(f"Command {command} failed but should_noack false: {e}")
+                self.fail(f"Command {command} failed but should_noack false: {e!r}")
 
     async def test_base_commands(self):
         for device_id, device in self.device_dict.items():

--- a/tests/test_mock_devices.py
+++ b/tests/test_mock_devices.py
@@ -1,4 +1,4 @@
-# This file is part of ts_ATDomeTrajectory.
+# This file is part of ts_MTMount.
 #
 # Developed for the LSST Telescope and Site Systems.
 # This product includes software developed by the LSST Project

--- a/tests/test_telemetry_client.py
+++ b/tests/test_telemetry_client.py
@@ -23,7 +23,6 @@ import asyncio
 import contextlib
 import json
 import logging
-import math
 import pathlib
 import time
 import unittest
@@ -187,12 +186,9 @@ class TelemetryClientTestCase(asynctest.TestCase):
                 timestamp=ccw_llv_data["timestamp"],
             )
             await self.publish_data(ccw_llv_data)
-            ccw_dds_data = await self.assert_next_telemetry(
+            await self.assert_next_telemetry(
                 self.remote.tel_cameraCableWrap, desired_ccw_dds_data
             )
-            self.assertTrue(math.isnan(ccw_dds_data.accelerationActual))
-            self.assertTrue(math.isnan(ccw_dds_data.angleSet))
-            self.assertTrue(math.isnan(ccw_dds_data.velocitySet))
 
     async def assert_next_telemetry(
         self, topic, desired_data, delta=1e-7, timeout=STD_TIMEOUT

--- a/tests/test_telemetry_client.py
+++ b/tests/test_telemetry_client.py
@@ -31,7 +31,6 @@ import asynctest
 import yaml
 import numpy as np
 
-from lsst.ts.idl.enums.MTMount import DriveState
 from lsst.ts import salobj
 from lsst.ts import hexrotcomm
 from lsst.ts import MTMount
@@ -45,10 +44,6 @@ CONNECT_TIMEOUT = 5
 
 class TelemetryClientTestCase(asynctest.TestCase):
     async def setUp(self):
-        self.driveStateToStr = {
-            value: key for key, value in MTMount.DriveStateDict.items()
-        }
-
         telemetry_map_path = (
             pathlib.Path(__file__).parents[1] / "data" / "telemetry_map.yaml"
         )
@@ -167,22 +162,16 @@ class TelemetryClientTestCase(asynctest.TestCase):
             # CCW is tricky for now because the telemetry
             # is heavily massaged and some fields are unknown.
 
-            DriveStateNameDict = {
-                value: key for key, value in MTMount.DriveStateDict.items()
-            }
             ccw_llv_data = dict(
-                cCWStatusDrive1=DriveStateNameDict[DriveState.MOVING],
-                cCWStatusDrive2=DriveStateNameDict[DriveState.OFF],
-                cCWAngle1=12.3,
-                cCWAngle2=-34.5,
-                cCWSpeed1=1.23,
-                cCWSpeed2=-3.45,
+                angle=12.3,
+                speed=-34.5,
+                acceleration=1.23,
                 timestamp=time.time(),
                 topicID=MTMount.TelemetryTopicId.CAMERA_CABLE_WRAP,
             )
             desired_ccw_dds_data = dict(
-                angleActual=ccw_llv_data["cCWAngle1"],
-                velocityActual=ccw_llv_data["cCWSpeed1"],
+                angleActual=ccw_llv_data["angle"],
+                velocityActual=ccw_llv_data["speed"],
                 timestamp=ccw_llv_data["timestamp"],
             )
             await self.publish_data(ccw_llv_data)
@@ -273,11 +262,6 @@ class TelemetryClientTestCase(asynctest.TestCase):
         value : `str`
             DDS value.
         """
-        if llv_key.endswith("StatusDrive"):
-            for i, item in enumerate(value):
-                llv_data[llv_key + str(i + 1)] = self.driveStateToStr[item]
-            return
-
         if isinstance(value, list):
             for i, item in enumerate(value):
                 llv_data[llv_key + str(i + 1)] = item

--- a/tests/test_telemetry_client.py
+++ b/tests/test_telemetry_client.py
@@ -112,12 +112,12 @@ class TelemetryClientTestCase(asynctest.TestCase):
             # Arbitrary values that are suitable for both
             # the elevation and azimuth telemetry topics.
             desired_elaz_dds_data = dict(
-                angleActual=55.1,
-                angleSet=45.2,
-                velocityActual=1.3,
-                velocitySet=1.4,
-                accelerationActual=-0.5,
-                torqueActual=3.3,
+                actualPosition=55.1,
+                demandPosition=45.2,
+                actualVelocity=1.3,
+                demandVelocity=1.4,
+                actualAcceleration=-0.5,
+                actualTorque=3.3,
                 timestamp=time.time(),
             )
             # topic_id is from telemetry_map.yaml
@@ -125,6 +125,7 @@ class TelemetryClientTestCase(asynctest.TestCase):
                 dds_data=desired_elaz_dds_data,
                 topic_id=MTMount.TelemetryTopicId.AZIMUTH,
             )
+            azimuth_llv_data["this_extra_field_should_be_ignored"] = 55.2
             await self.publish_data(azimuth_llv_data)
             await self.assert_next_telemetry(
                 self.remote.tel_azimuth, desired_elaz_dds_data
@@ -159,20 +160,15 @@ class TelemetryClientTestCase(asynctest.TestCase):
                 self.remote.tel_elevationDrives, desired_elevation_drives_dds_data
             )
 
-            # CCW is tricky for now because the telemetry
-            # is heavily massaged and some fields are unknown.
-
-            ccw_llv_data = dict(
-                angle=12.3,
-                speed=-34.5,
-                acceleration=1.23,
-                timestamp=time.time(),
-                topicID=MTMount.TelemetryTopicId.CAMERA_CABLE_WRAP,
-            )
             desired_ccw_dds_data = dict(
-                angleActual=ccw_llv_data["angle"],
-                velocityActual=ccw_llv_data["speed"],
-                timestamp=ccw_llv_data["timestamp"],
+                actualPosition=12.3,
+                actualVelocity=-34.5,
+                actualAcceleration=0.25,
+                timestamp=time.time(),
+            )
+            ccw_llv_data = self.convert_dds_data_to_llv(
+                dds_data=desired_ccw_dds_data,
+                topic_id=MTMount.TelemetryTopicId.CAMERA_CABLE_WRAP,
             )
             await self.publish_data(ccw_llv_data)
             await self.assert_next_telemetry(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-# This file is part of ts_ATDomeTrajectory.
+# This file is part of ts_MTMount.
 #
 # Developed for the LSST Telescope and Site Systems.
 # This product includes software developed by the LSST Project

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -44,6 +44,7 @@ class ValidationTestCase(unittest.TestCase):
             connection_timeout=10,
             ack_timeout=10,
             camera_cable_wrap_advance_time=0.02,
+            max_rotator_position_error=0.1,
         )
 
     def test_default(self):
@@ -69,7 +70,12 @@ class ValidationTestCase(unittest.TestCase):
                         self.assertEqual(result[field], default_value)
 
     def test_all_specified(self):
-        data = dict(host="1.2.3.4", connection_timeout=3.4, ack_timeout=4.5)
+        data = dict(
+            host="1.2.3.4",
+            connection_timeout=3.4,
+            ack_timeout=4.5,
+            max_rotator_position_error=1.2,
+        )
         data_copy = data.copy()
         result = self.validator.validate(data)
         self.assertEqual(data, data_copy)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,4 +1,4 @@
-# This file is part of ts_ATDomeTrajectory.
+# This file is part of ts_MTMount.
 #
 # Developed for the LSST Telescope and Site Systems.
 # This product includes software developed by the LSST Project


### PR DESCRIPTION
The simplest way to review this is probably to compare the differences between this branch and tickets/DM-28362.
There should be few changes, as follows:
* For the ccw_only branch the CSC pretends to be the HHD, whereas the develop branch uses the new dedicated port. This is reflected in using a different port and a different code for the AskForCommand low-level command.
* Several CSC commands are disabled, as are the associated unit tests.

Note: I am still using a pair of sockets to communicate with the low-level controller because updating that for a single socket (which is what the real TMA will use) will be very disruptive and make it much more difficult to keep the develop and ccw_only branches in synch.