### PR TITLE
DM-33266: AxisDevice: fix the out-of-range error message and expand the elevation range

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,23 @@
 Version History
 ###############
 
+v0.20.1
+-------
+
+Changes:
+
+* Expand the elevation limits back to 0, 90, to match LTS-103.
+* `mock.AxisDevice`: fix the "out of range" error message.
+  It was printing the minimum value as the upper limit, instead of the maximum value.
+
+Requires:
+
+* ts_salobj 6.3
+* ts_simactuators 2
+* ts_tcpip 0.1
+* ts_idl 3.2
+* IDL files for MTMount and MTRotator from ts_xml 10.1
+
 v0.20.0
 -------
 

--- a/python/lsst/ts/mtmount/mock/axis_device.py
+++ b/python/lsst/ts/mtmount/mock/axis_device.py
@@ -273,7 +273,7 @@ class AxisDevice(BaseDevice):
         ):
             raise ValueError(
                 f"position={command.position} not in range [{self.cmd_limits.min_position}, "
-                f"{self.cmd_limits.min_position}]"
+                f"{self.cmd_limits.max_position}]"
             )
         if abs(command.velocity) > self.cmd_limits.max_velocity:
             raise ValueError(

--- a/python/lsst/ts/mtmount/mock/limits.py
+++ b/python/lsst/ts/mtmount/mock/limits.py
@@ -62,9 +62,10 @@ class Limits:
 # Command limits for the mock axis controllers.
 # Scaled up versions are used for computing slews.
 CmdLimitsDict = {
-    # From LTS-103.
+    # From LTS-103. Note that LTS-103 also specifies that the performance
+    # requirements need only be met between 15 and 86.5 degrees.
     System.ELEVATION: Limits(
-        min_position=20, max_position=86.5, max_velocity=3.5, max_acceleration=3.5
+        min_position=0, max_position=90.0, max_velocity=3.5, max_acceleration=3.5
     ),
     # From LTS-103.
     System.AZIMUTH: Limits(


### PR DESCRIPTION
If it is important to have the elevation limits expanded I'm happy to add that to this PR. Just let me know.