### PR TITLE
DM-34790: Reset oil supply subsystem alarms

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -16,6 +16,8 @@ Changes:
   * Call ``super().start()`` at the beginning of the start method.
     This requires ts_salobj 7.1.
   * Make going to fault more robust when the connection to the low-level controller is lost.
+  * Reset the oil supply system alarms when resetting other alarms.
+  * Turn on the oil supply system before the main axes power supply, instead of after.
 
 * `TelemetryClient`: make the controller write-only.
   This requires ts_salobj 7.1.

--- a/python/lsst/ts/mtmount/mtmount_csc.py
+++ b/python/lsst/ts/mtmount/mtmount_csc.py
@@ -695,8 +695,10 @@ class MTMountCsc(salobj.ConfigurableCsc):
         self.log.info("Enable devices")
         self.disable_task.cancel()
         try:
+            # Reset all systems the CSC controls
             for reset_command in [
                 commands.TopEndChillerResetAlarm(),
+                commands.OilSupplySystemResetAlarm(),
                 commands.MainAxesPowerSupplyResetAlarm(),
                 commands.MirrorCoverLocksResetAlarm(),
                 commands.MirrorCoversResetAlarm(),
@@ -711,11 +713,13 @@ class MTMountCsc(salobj.ConfigurableCsc):
                         f"Command {reset_command} failed; continuing: {e!r}"
                     )
 
+            # Power on the systems that we want to be on all the time
+            # (all systems the CSC controls, except mirror covers)
             power_on_commands = [
                 commands.TopEndChillerPower(on=True),
                 commands.TopEndChillerTrackAmbient(on=True, temperature=0),
-                commands.MainAxesPowerSupplyPower(on=True),
                 commands.OilSupplySystemPower(on=True),
+                commands.MainAxesPowerSupplyPower(on=True),
                 commands.AzimuthPower(on=True),
                 commands.ElevationPower(on=True),
                 commands.CameraCableWrapPower(on=True),


### PR DESCRIPTION
Also turn on the oil supply system *before* turning on the main axes power supply.