### PR TITLE
DM-46854: Update how MTMount handles commands timeouts when a timeout is specified.

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,41 @@
 Version History
 ###############
 
+v0.31.0
+-------
+
+* In ``MTMountCSC``:
+
+  * Updated how _basic_send_command handles timeouts.
+    If no timeout is specified, use the current strategy.
+    If a timeout is specified add that to the total timeout.
+
+  * Report in_progress while executing the start command.
+
+  * Updated commands used to park/unpark the telescope based on what the EUI does.
+
+  * Keep a list of commands sent and log them in case of a fault.
+
+  * When MTMount goes to fault, check if rotator is enabled and send it to DISABLED to avoid causing it to go to Fault.
+
+  * Lock the main axes when stopping track.
+
+  * Keep track of track_started command so it is not sent more than once per tracking.
+
+  * Updated trackTarget command to raise an exception if tracking is not started.
+    
+    This was previously handled sort of by the TMA software but now that the CSC is keeping track of whether it started tracking or not, we can reject the command without having to send it out to the controller.
+
+  * Updated do_startTracking to log command history if BothAxesEnableTracking command fails.
+
+  * Updated do_trackTarget to allow skipping commands that had timeout internally on the TMA side and to log the command history when track target command fails.
+    
+    Sometimes the TMA software will have timeouts when sending track demands internally.
+    We noticed that, most times it is ok to skip one or two subsequent failures.
+    This change ensures that the CSC will ignore these particular issues, so long as they happen at most a max_subsequent_failed_track_target number of times.
+    In any case, the CSC will log the command history when this happens so we can track down what was going on.
+
+
 v0.30.1
 -------
 

--- a/python/lsst/ts/mtmount/mtmount_csc.py
+++ b/python/lsst/ts/mtmount/mtmount_csc.py
@@ -471,7 +471,7 @@ class MTMountCsc(salobj.ConfigurableCsc):
                 )
 
         self.rotator = salobj.Remote(
-            domain=self.domain, name="MTRotator", include=["rotation"]
+            domain=self.domain, name="MTRotator", include=["rotation", "summaryState"]
         )
 
         self.mtmount_remote = salobj.Remote(
@@ -584,6 +584,23 @@ class MTMountCsc(salobj.ConfigurableCsc):
 
     async def end_standby(self, data):
         await super().begin_standby(data)
+        try:
+            rotator_summary_state = await self.rotator.evt_summaryState.aget(
+                timeout=self.config.connection_timeout
+            )
+        except asyncio.TimeoutError:
+            self.log.warning("Could not determine rotator state. Continuing.")
+        else:
+            try:
+                if rotator_summary_state.summaryState == salobj.State.ENABLED:
+                    self.log.warning(
+                        "Rotator in Enabled state. Disabling Rotator so it won't fault."
+                    )
+                    await self.rotator.cmd_disable.start(
+                        timeout=self.config.connection_timeout
+                    )
+            except asyncio.TimeoutError:
+                self.log.warning("Could not disable rotator. Continuing.")
         await self.disconnect()
 
     @staticmethod

--- a/python/lsst/ts/mtmount/mtmount_csc.py
+++ b/python/lsst/ts/mtmount/mtmount_csc.py
@@ -1197,12 +1197,13 @@ class MTMountCsc(salobj.ConfigurableCsc):
         await self.client.write(command_bytes)
         initial_timeout = self.config.ack_timeout if timeout is None else timeout
         new_timeout = await asyncio.wait_for(command_futures.ack, initial_timeout)
+        timeout_buffer = TIMEOUT_BUFFER if timeout is None else TIMEOUT_BUFFER + timeout
         if not command_futures.done.done():
             try:
                 await asyncio.wait_for(
                     command_futures.done,
                     timeout=(
-                        (TIMEOUT_BUFFER + new_timeout)
+                        (timeout_buffer + new_timeout)
                         if new_timeout is not None
                         else None
                     ),
@@ -1210,7 +1211,7 @@ class MTMountCsc(salobj.ConfigurableCsc):
             except asyncio.TimeoutError:
                 self.command_futures_dict.pop(command.sequence_id, None)
                 raise asyncio.TimeoutError(
-                    f"Command {command} timed out after {new_timeout + TIMEOUT_BUFFER} seconds"
+                    f"Command {command} timed out after {new_timeout + timeout_buffer} seconds."
                 )
         return command_futures
 

--- a/python/lsst/ts/mtmount/mtmount_csc.py
+++ b/python/lsst/ts/mtmount/mtmount_csc.py
@@ -1736,7 +1736,8 @@ class MTMountCsc(salobj.ConfigurableCsc):
             self.log.info("Ignoring a stopTracking command: already disabling devices")
             return
         await self.cmd_stopTracking.ack_in_progress(data, timeout=STOP_TIMEOUT)
-        await self.send_command(commands.BothAxesStop(), do_lock=False)
+        async with self.main_axes_lock:
+            await self.send_command(commands.BothAxesStop(), do_lock=False)
 
     async def do_applySettingsSet(self, data):
         """Handle the applySettingsSet command."""

--- a/python/lsst/ts/mtmount/mtmount_csc.py
+++ b/python/lsst/ts/mtmount/mtmount_csc.py
@@ -1650,6 +1650,8 @@ class MTMountCsc(salobj.ConfigurableCsc):
         slow_lock_task = asyncio.create_task(print_slow_lock(data.taiTime))
 
         async with self.main_axes_lock:
+            if not self.track_started:
+                raise salobj.ExpectedError("Tracking not started.")
             slow_lock_task.cancel()
             # Note: the time now (the time at which the lock was obtained)
             # is essentially the same as the time at which the command will be

--- a/python/lsst/ts/mtmount/mtmount_csc.py
+++ b/python/lsst/ts/mtmount/mtmount_csc.py
@@ -564,9 +564,12 @@ class MTMountCsc(salobj.ConfigurableCsc):
             data=data,
             timeout=self.config.connection_timeout * 2.0,
         )
-        self.connect_task.cancel()
-        self.connect_task = asyncio.create_task(self.connect())
-        await self.connect_task
+        async with self.in_progress_loop(
+            ack_in_progress=self.cmd_start.ack_in_progress, data=data
+        ):
+            self.connect_task.cancel()
+            self.connect_task = asyncio.create_task(self.connect())
+            await self.connect_task
 
     async def end_standby(self, data):
         await super().begin_standby(data)

--- a/python/lsst/ts/mtmount/mtmount_csc.py
+++ b/python/lsst/ts/mtmount/mtmount_csc.py
@@ -267,6 +267,13 @@ class MTMountCsc(salobj.ConfigurableCsc):
     # reports all limits rounded to 2 decimal places.
     limits_margin = 0.01
 
+    # Velocity to use when parking/unparking
+    # the TMA (in deg/s)
+    park_velocity = 0.1
+    # Acceleration to use when parking/unparking
+    # the TMA (in deg/s^2)
+    park_acceleration = 0.1
+
     def __init__(
         self,
         config_dir=None,
@@ -1723,9 +1730,10 @@ class MTMountCsc(salobj.ConfigurableCsc):
             self.log.info(f"Moving telescope to {park_position.name} park position.")
 
             cmd_futures = await self.send_command(
-                commands.BothAxesMove(
-                    azimuth=park_position_altaz["azimuth"],
-                    elevation=park_position_altaz["elevation"],
+                commands.ElevationMove(
+                    position=park_position_altaz["elevation"],
+                    velocity=self.park_velocity,
+                    acceleration=self.park_acceleration,
                 ),
                 do_lock=True,
             )
@@ -1818,9 +1826,10 @@ class MTMountCsc(salobj.ConfigurableCsc):
             )
 
             cmd_futures = await self.send_command(
-                commands.BothAxesMove(
-                    azimuth=unpark_azimuth,
-                    elevation=unpark_elevation,
+                commands.ElevationMove(
+                    position=unpark_elevation,
+                    velocity=self.park_velocity,
+                    acceleration=self.park_acceleration,
                 ),
                 do_lock=True,
             )

--- a/python/lsst/ts/mtmount/mtmount_csc.py
+++ b/python/lsst/ts/mtmount/mtmount_csc.py
@@ -1711,9 +1711,13 @@ class MTMountCsc(salobj.ConfigurableCsc):
         )
         if not self.track_started:
             async with self.main_axes_lock:
-                await self.send_command(
-                    commands.BothAxesEnableTracking(), do_lock=False
-                )
+                try:
+                    await self.send_command(
+                        commands.BothAxesEnableTracking(), do_lock=False
+                    )
+                except Exception:
+                    await self.log_command_history()
+                    raise
             self.track_started = True
         else:
             self.log.info("Tracking already started, not sending command again.")


### PR DESCRIPTION
This ticket ended up accumulating a lot more work than initially anticipated. Since I have it opened when we started working with ComCam on-sky, I ended up using it to debug and update a lot of the interaction with the TMA controller.

This is the final collection of changes made during the ComCam campaign. There are other things still needed to be updated, but those have their own tickets and will be updated later.