### PR TITLE
DM-49991: Update MTMount CSC to publish capacitor bank telemetry.

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,30 @@
 Version History
 ###############
 
+v0.33.0
+-------
+
+- Updates to the CSC:
+
+  - Updated unpark command to leave CSC in the park/unpark state at the end.
+
+  - Updated park velocity to 0.5deg/s.
+
+  - Allow the lock/unlock motion commands to be executed when the CSC is in Disabled or Enabled.
+
+  - Fixed issue with the unlockMotion command which would leave the system in UNLOCKING if the command was sent when the CSC was already locked.
+
+  - Updated handle_apply_settings_set first load the new settings and then to only power off/on the elevation and azimuth axis.
+
+  - Updated _disable_devices_impl to change order in which the drives are disabled.
+    Do elevation before azimuth.
+
+  - Updated handle_apply_settings_set to await for devices to disable, intead of doing that in the background.
+
+- In mtmount_ccw_only_csc, allows lock/unlock motion commands.
+
+- Added new capacitor bank telemetry.
+
 v0.32.1
 -------
 

--- a/python/lsst/ts/mtmount/mtmount_ccw_only_csc.py
+++ b/python/lsst/ts/mtmount/mtmount_ccw_only_csc.py
@@ -130,14 +130,6 @@ class MTMountCcwOnlyCsc(MTMountCsc):
         """
         raise ExpectedError("Command not available in CCW only version of CSC.")
 
-    async def do_lockMotion(self, data):
-        self.assert_enabled()
-        raise ExpectedError("Command not available in CCW only version of CSC.")
-
-    async def do_unlockMotion(self, data):
-        self.assert_enabled()
-        raise ExpectedError("Command not available in CCW only version of CSC.")
-
 
 def run_mtmount_ccw_only() -> None:
     """Run the MTMountCcwOnly CSC."""

--- a/python/lsst/ts/mtmount/mtmount_csc.py
+++ b/python/lsst/ts/mtmount/mtmount_csc.py
@@ -1990,11 +1990,9 @@ class MTMountCsc(salobj.ConfigurableCsc):
             )
             await cmd_futures.done
 
-            # reset settings
-            await self.handle_apply_settings_set(
-                restore_defaults=True,
-                settings_to_apply=[],
-            )
+            # Will leave the mount in the park/unpark settings.
+            # It is on the user to load the settings they want
+            # to operate later.
 
     async def do_lockMotion(self, data):
         assert (

--- a/python/lsst/ts/mtmount/mtmount_csc.py
+++ b/python/lsst/ts/mtmount/mtmount_csc.py
@@ -2043,6 +2043,9 @@ class MTMountCsc(salobj.ConfigurableCsc):
             raise salobj.ExpectedError(
                 f"Currently {lock_state!r}. Cannot unlock motion."
             )
+        elif self.evt_motionLockState.data.lockState == MotionLockState.UNLOCKED:
+            self.log.debug("Already locked.")
+            return
 
         await self.evt_motionLockState.set_write(
             lockState=MotionLockState.UNLOCKING,

--- a/python/lsst/ts/mtmount/mtmount_csc.py
+++ b/python/lsst/ts/mtmount/mtmount_csc.py
@@ -1046,7 +1046,7 @@ class MTMountCsc(salobj.ConfigurableCsc):
                 await self.disable_devices()
             finally:
                 await self.log_command_history()
-        elif self.summary_state == salobj.State.ENABLED:
+        elif self.disabled_or_enabled:
             await self.evt_motionLockState.set_write(
                 lockState=MotionLockState.UNLOCKED,
                 identity="",
@@ -1997,7 +1997,9 @@ class MTMountCsc(salobj.ConfigurableCsc):
             )
 
     async def do_lockMotion(self, data):
-        self.assert_enabled_and_not_disabling()
+        assert (
+            self.disabled_or_enabled
+        ), "CSC needs to be in Disabled or Enabled to lock motion."
 
         if self.track_started:
             raise salobj.ExpectedError(
@@ -2034,7 +2036,11 @@ class MTMountCsc(salobj.ConfigurableCsc):
             )
 
     async def do_unlockMotion(self, data):
-        self.assert_enabled_and_not_disabling()
+
+        assert (
+            self.disabled_or_enabled
+        ), "CSC needs to be in Disabled or Enabled to unlock motion."
+
         if self.evt_motionLockState.data.lockState in {
             MotionLockState.LOCKING,
             MotionLockState.UNLOCKING,

--- a/python/lsst/ts/mtmount/mtmount_csc.py
+++ b/python/lsst/ts/mtmount/mtmount_csc.py
@@ -271,7 +271,7 @@ class MTMountCsc(salobj.ConfigurableCsc):
 
     # Velocity to use when parking/unparking
     # the TMA (in deg/s)
-    park_velocity = 0.1
+    park_velocity = 0.5
     # Acceleration to use when parking/unparking
     # the TMA (in deg/s^2)
     park_acceleration = 0.1

--- a/python/lsst/ts/mtmount/mtmount_csc.py
+++ b/python/lsst/ts/mtmount/mtmount_csc.py
@@ -994,8 +994,8 @@ class MTMountCsc(salobj.ConfigurableCsc):
             for command in [
                 commands.BothAxesStop(),
                 commands.CameraCableWrapStop(),
-                commands.AzimuthPower(on=False),
                 commands.ElevationPower(on=False),
+                commands.AzimuthPower(on=False),
                 commands.CameraCableWrapPower(on=False),
             ]:
                 try:

--- a/python/lsst/ts/mtmount/telemetry_map.py
+++ b/python/lsst/ts/mtmount/telemetry_map.py
@@ -841,6 +841,40 @@ RAW_TELEMETRY_MAP = yaml.safe_load(
   glycolTemperaturePier0002: 1
   glycolTemperaturePier0002Timestamp: 1
   timestamp: 1
+
+18:
+- capacitorBank
+- blownAzimuth3Fuse: 4
+  blownAzimuth3FuseTimestamp: 4
+  blownAzimuth4Fuse: 4
+  blownAzimuth4FuseTimestamp: 4
+  blownAzimuth5Fuse: 4
+  blownAzimuth5FuseTimestamp: 4
+  blownAzimuth6Fuse: 4
+  blownAzimuth6FuseTimestamp: 4
+  blownElevation7Fuse: 6
+  blownElevation7FuseTimestamp: 6
+  blownElevation8Fuse: 6
+  blownElevation8FuseTimestamp: 6
+  currentCapacitorBank1Fuse: 5
+  currentCapacitorBank1FuseTimestamp: 5
+  currentCapacitorBank2Fuse: 5
+  currentCapacitorBank2FuseTimestamp: 5
+  currentCapacitorBank3Fuse: 5
+  currentCapacitorBank3FuseTimestamp: 5
+  currentCapacitorBank4Fuse: 5
+  currentCapacitorBank4FuseTimestamp: 5
+  currentCapacitorBank5Fuse: 5
+  currentCapacitorBank5FuseTimestamp: 5
+  currentCapacitorBank6Fuse: 5
+  currentCapacitorBank6FuseTimestamp: 5
+  currentCapacitorBank7Fuse: 5
+  currentCapacitorBank7FuseTimestamp: 5
+  currentCapacitorBank8Fuse: 5
+  currentCapacitorBank8FuseTimestamp: 5
+  internalTemperatureCapacitorBank: 8
+  internalTemperatureCapacitorBankTimestamp: 8
+  timestamp: 1
 """
 )
 

--- a/tests/data/config/_init.yaml
+++ b/tests/data/config/_init.yaml
@@ -11,6 +11,6 @@ park_positions:
     elevation: 90.0
     azimuth: 0.0
   horizon:
-    elevation: 0.0
+    elevation: 6.0
     azimuth: 0.0
 

--- a/tests/test_ccw_only_csc.py
+++ b/tests/test_ccw_only_csc.py
@@ -612,7 +612,11 @@ class CcwOnlyCscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCas
                     "stopTracking",
                     "trackTarget",
                     "unpark",
-                )
+                ),
+                skip_commands=[
+                    "lockMotion",
+                    "unlockMotion",
+                ],
             )
 
     def make_track_target_kwargs(

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -2010,6 +2010,13 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
     async def test_unpark_telescope_unparked(self):
 
         async with self.make_csc(initial_state=salobj.State.ENABLED):
+
+            await self.remote.cmd_moveToTarget.set_start(
+                azimuth=0.0,
+                elevation=45.0,
+                timeout=STD_TIMEOUT,
+            )
+
             with pytest.raises(salobj.AckError, match="outside unparking position"):
                 await self.remote.cmd_unpark.start()
 

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -634,12 +634,16 @@ class CscTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsyncioTestCase):
                 "stopTracking",
                 "trackTarget",
                 "unpark",
+            ]
+
+            skip_commands = [
                 "lockMotion",
                 "unlockMotion",
             ]
 
             await self.check_standard_state_transitions(
-                enabled_commands=enabled_commands
+                enabled_commands=enabled_commands,
+                skip_commands=skip_commands,
             )
 
     def make_track_target_kwargs(

--- a/tests/test_telemetry_client.py
+++ b/tests/test_telemetry_client.py
@@ -207,6 +207,10 @@ class TelemetryClientTestCase(unittest.IsolatedAsyncioTestCase):
                         values = [
                             int(value) for value in random.integers(0, 10000, fieldlen)
                         ]
+                    elif dtype is bool:
+                        values = [
+                            bool(value) for value in random.integers(0, 10000, fieldlen)
+                        ]
                     else:
                         raise RuntimeError(
                             f"Unrecognized {dtype=} for {sal_topic_name}.{fieldname}, {null_field_data=}"


### PR DESCRIPTION
In addition to the capacitor bank telemetry I also did  some work on the park/unpark/apply settings set.

With these changes applying settings set works well. We did some minimal tests with park and unpark and they seem to work but we need to give it more road time to see how reliable it is.